### PR TITLE
fix(security): add files allowlist to prevent credential leaks [BUG-729]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.env*
+node_modules/
+*.tgz
+.DS_Store

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,7 @@
+# Defense-in-depth: the "files" field in package.json is the primary guard.
+.env*
+.git/
+.github/
+test-*
+node_modules/
+*.tgz

--- a/package.json
+++ b/package.json
@@ -16,5 +16,10 @@
     "url": "https://github.com/Survicate/survicate-web-package/issues"
   },
   "main": "survicate_widget.js",
-  "types": "survicate_widget.d.ts"
+  "types": "survicate_widget.d.ts",
+  "files": [
+    "survicate_widget.js",
+    "survicate_widget.d.ts",
+    "README.md"
+  ]
 }


### PR DESCRIPTION
## Summary

BUG-729 follow-up: Identical vulnerability to the wrapper package that leaked production credentials for 60 days. This package currently has no `files` field, no `.npmignore`, no `.gitignore`.

### Changes
- Add `"files"` allowlist to `package.json` — only `survicate_widget.js`, `survicate_widget.d.ts`, and `README.md` are published
- Add `.npmignore` as defense-in-depth
- Add `.gitignore` for local file hygiene

### Context

The repo is currently clean (only 4 files), but without guardrails any file added to the working directory during a manual `npm publish` would be included — exactly what happened with the wrapper package.

### Verification

`npm pack --dry-run` produces 4 files / 761KB (unchanged content, just protected now).

### Note

Merge this **after** the static PR ([module-surveys-web#1801](https://github.com/Survicate/module-surveys-web/pull/1801)) is deployed. The `npm-pr.yaml` workflow will auto-create a version branch on top of this — merging that branch will include both the new widget build and these security guardrails.