### PR TITLE
Chore: add workflow_dispatch publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,6 +11,10 @@ on:
         description: 'Short release description'
         required: true
 
+concurrency:
+  group: publish
+  cancel-in-progress: false
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -26,8 +30,9 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Check version not already published
+      - name: Check version not already tagged
         run: |
+          set -o pipefail
           VERSION=$(jq -r .version package.json)
           if git ls-remote --tags origin | grep -q "refs/tags/v${VERSION}$"; then
             echo "::error::Tag v${VERSION} already exists. Bump the version in package.json first."
@@ -48,6 +53,12 @@ jobs:
             exit 1
           fi
 
+      - name: Create git tag
+        run: |
+          VERSION=$(jq -r .version package.json)
+          git tag "v${VERSION}"
+          git push origin "v${VERSION}"
+
       - name: Publish
         run: npm publish --ignore-scripts
         env:
@@ -59,8 +70,6 @@ jobs:
           RELEASE_NOTES: ${{ github.event.inputs.release_notes }}
         run: |
           VERSION=$(jq -r .version package.json)
-          git tag "v${VERSION}"
-          git push origin "v${VERSION}"
           notes_file="$(mktemp)"
           trap 'rm -f "$notes_file"' EXIT
           printf '%s' "$RELEASE_NOTES" > "$notes_file"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -34,14 +34,18 @@ jobs:
         run: |
           set -o pipefail
           VERSION=$(jq -r .version package.json)
-          if git ls-remote --tags origin | grep -q "refs/tags/v${VERSION}$"; then
+          if git ls-remote --exit-code --tags --refs origin "refs/tags/v${VERSION}" >/dev/null 2>&1; then
             echo "::error::Tag v${VERSION} already exists. Bump the version in package.json first."
             exit 1
           fi
 
       - name: Safety check
         run: |
-          pack_output="$(npm pack --dry-run --ignore-scripts 2>&1)"
+          pack_output="$(npm pack --dry-run --ignore-scripts 2>&1)" || {
+            echo "::error::npm pack failed:"
+            printf '%s\n' "$pack_output"
+            exit 1
+          }
           printf '%s\n' "$pack_output"
           pack_files="$(printf '%s\n' "$pack_output" \
             | grep '^npm notice ' \
@@ -53,16 +57,16 @@ jobs:
             exit 1
           fi
 
+      - name: Publish
+        run: npm publish --ignore-scripts
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Create git tag
         run: |
           VERSION=$(jq -r .version package.json)
           git tag "v${VERSION}"
           git push origin "v${VERSION}"
-
-      - name: Publish
-        run: npm publish --ignore-scripts
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub release
         env:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,12 +20,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.ref }}
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
@@ -58,9 +59,7 @@ jobs:
           fi
 
       - name: Publish
-        run: npm publish --ignore-scripts
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --ignore-scripts --provenance
 
       - name: Create git tag
         run: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Check version not already tagged
         run: |
           set -o pipefail
-          VERSION=$(jq -r .version package.json)
+          VERSION=$(node -p "require('./package.json').version")
           if git ls-remote --exit-code --tags --refs origin "refs/tags/v${VERSION}" >/dev/null 2>&1; then
             echo "::error::Tag v${VERSION} already exists. Bump the version in package.json first."
             exit 1
@@ -63,7 +63,7 @@ jobs:
 
       - name: Create git tag
         run: |
-          VERSION=$(jq -r .version package.json)
+          VERSION=$(node -p "require('./package.json').version")
           git tag "v${VERSION}"
           git push origin "v${VERSION}"
 
@@ -72,7 +72,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_NOTES: ${{ github.event.inputs.release_notes }}
         run: |
-          VERSION=$(jq -r .version package.json)
+          VERSION=$(node -p "require('./package.json').version")
           notes_file="$(mktemp)"
           trap 'rm -f "$notes_file"' EXIT
           printf '%s' "$RELEASE_NOTES" > "$notes_file"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,37 @@
+name: Publish to NPM
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch or tag to publish from'
+        required: false
+        default: 'development'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.ref }}
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Safety check
+        run: |
+          pack_output="$(npm pack --dry-run --ignore-scripts 2>&1)"
+          printf '%s\n' "$pack_output"
+          pack_files="$(printf '%s\n' "$pack_output" | grep '^npm notice ' | grep -vE '(Tarball Details|Tarball Contents|name:|version:|filename:|package size:|unpacked size:|shasum:|integrity:|total files:)' || true)"
+          if printf '%s\n' "$pack_files" | grep -qiE '\.env|credentials|secret|\.pem|\.key|\.npmrc|id_rsa|id_ed25519'; then
+            echo "::error::Sensitive files detected in npm package! Aborting."
+            exit 1
+          fi
+
+      - name: Publish
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -26,6 +26,14 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Check version not already published
+        run: |
+          VERSION=$(jq -r .version package.json)
+          if git ls-remote --tags origin | grep -q "refs/tags/v${VERSION}$"; then
+            echo "::error::Tag v${VERSION} already exists. Bump the version in package.json first."
+            exit 1
+          fi
+
       - name: Safety check
         run: |
           pack_output="$(npm pack --dry-run --ignore-scripts 2>&1)"
@@ -48,10 +56,14 @@ jobs:
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_NOTES: ${{ github.event.inputs.release_notes }}
         run: |
           VERSION=$(jq -r .version package.json)
           git tag "v${VERSION}"
           git push origin "v${VERSION}"
+          notes_file="$(mktemp)"
+          trap 'rm -f "$notes_file"' EXIT
+          printf '%s' "$RELEASE_NOTES" > "$notes_file"
           gh release create "v${VERSION}" \
             --title "v${VERSION}" \
-            --notes "${{ github.event.inputs.release_notes }}"
+            --notes-file "$notes_file"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,10 +7,15 @@ on:
         description: 'Branch or tag to publish from'
         required: false
         default: 'development'
+      release_notes:
+        description: 'Short release description'
+        required: true
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -25,13 +30,28 @@ jobs:
         run: |
           pack_output="$(npm pack --dry-run --ignore-scripts 2>&1)"
           printf '%s\n' "$pack_output"
-          pack_files="$(printf '%s\n' "$pack_output" | grep '^npm notice ' | grep -vE '(Tarball Details|Tarball Contents|name:|version:|filename:|package size:|unpacked size:|shasum:|integrity:|total files:)' || true)"
-          if printf '%s\n' "$pack_files" | grep -qiE '\.env|credentials|secret|\.pem|\.key|\.npmrc|id_rsa|id_ed25519'; then
+          pack_files="$(printf '%s\n' "$pack_output" \
+            | grep '^npm notice ' \
+            | grep -vE '(Tarball Details|Tarball Contents|name:|version:|filename:|package size:|unpacked size:|shasum:|integrity:|total files:)' \
+            | sed -E 's/^npm notice[[:space:]]+([0-9.]+[kKMGT]?B[[:space:]]+)?//' \
+            || true)"
+          if printf '%s\n' "$pack_files" | grep -qiE '(^|/)\.env(\.[^/]+)?$|(^|/)\.npmrc$|(^|/)(id_rsa|id_ed25519)$|(^|/)[^/]+\.(pem|key)$|(^|/)(credentials|secret|secrets)(\.(json|ya?ml|env|txt))?$'; then
             echo "::error::Sensitive files detected in npm package! Aborting."
             exit 1
           fi
 
       - name: Publish
-        run: npm publish
+        run: npm publish --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=$(jq -r .version package.json)
+          git tag "v${VERSION}"
+          git push origin "v${VERSION}"
+          gh release create "v${VERSION}" \
+            --title "v${VERSION}" \
+            --notes "${{ github.event.inputs.release_notes }}"


### PR DESCRIPTION
## Summary
- Adds a \`workflow_dispatch\` GitHub Actions workflow for publishing \`@survicate/survicate-web-package\` to npmjs.org
- Replaces local \`npm publish\` to prevent credential leaks (BUG-729)
- Uses **npm Trusted Publishing (OIDC)** — no \`NPM_TOKEN\` secret required; GitHub Actions is configured as a trusted publisher on npmjs.org, so a short-lived token is minted per run
- Includes a safety check that scans \`npm pack --dry-run\` output for sensitive files (\`.env\`, credentials, keys, etc.) before publishing
- Publishes with \`--provenance\` to generate a signed attestation linking the package to the exact Git commit and workflow run

## Setup required (one-time, before first run)
On the \`@survicate/survicate-web-package\` npmjs.org package page:
**Settings → Publishing → Trusted Publishers → Add a publisher → GitHub Actions**
- Owner: \`Survicate\`
- Repository: \`survicate-web-package\`
- Workflow filename: \`publish.yaml\`
- Environment: _(leave blank)_

## Test plan
- [x] Complete the Trusted Publisher setup on npmjs.org before triggering the workflow
- [ ] Verify the workflow appears in the Actions tab after merge
- [ ] Trigger the workflow manually and confirm it publishes successfully without any stored npm secret
- [ ] Confirm the safety check blocks publishing if sensitive files are detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)