### PR TITLE
Chore: fix npm publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -59,7 +59,7 @@ jobs:
           fi
 
       - name: Publish
-        run: npm publish --ignore-scripts --provenance
+        run: npm publish --ignore-scripts --provenance --access public
 
       - name: Create git tag
         run: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,10 +3,6 @@ name: Publish to NPM
 on:
   workflow_dispatch:
     inputs:
-      ref:
-        description: 'Branch or tag to publish from'
-        required: false
-        default: 'development'
       release_notes:
         description: 'Short release description'
         required: true
@@ -24,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.ref }}
+          ref: development
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Two fixes to the publish workflow:

**1. Add `--access public`**
Scoped packages (`@survicate/...`) default to `--access restricted` on npm, which causes a 404 when the package doesn't exist in the registry yet. Adding `--access public` fixes the publish.

**2. Restrict publishing to `development` branch only**
Removed the free-form `ref` input that allowed publishing from any branch. The workflow now always checks out `development`, so there's no way to accidentally publish from a feature or hotfix branch.