### PR TITLE
fix(ci): remove registry-url to allow npm trusted publishing via OIDC

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,6 +17,8 @@ jobs:
     permissions:
       contents: write
       id-token: write
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -56,6 +58,8 @@ jobs:
 
       - name: Publish
         run: npm publish --ignore-scripts --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create git tag
         run: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -27,7 +27,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Check version not already tagged
         run: |
@@ -58,8 +57,6 @@ jobs:
 
       - name: Publish
         run: npm publish --ignore-scripts --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create git tag
         run: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,8 +17,6 @@ jobs:
     permissions:
       contents: write
       id-token: write
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Fixes the `npm publish` 404 error.

`actions/setup-node` with `registry-url` injects `NODE_AUTH_TOKEN=GITHUB_TOKEN` into the environment via `.npmrc`. npm uses that token as the auth credential, which the registry rejects with 404, overriding the OIDC trusted publishing flow. Removing `registry-url` lets npm authenticate via the OIDC token directly.